### PR TITLE
removed nitch from .zshrc

### DIFF
--- a/extras/.zshrc
+++ b/extras/.zshrc
@@ -47,5 +47,5 @@ source $ZSH/oh-my-zsh.sh
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
-#neofetch
-nitch
+neofetch
+


### PR DESCRIPTION
there was nitch in the .zshrc file that would show the nitch when the user opens terminal. but it was not installed. so I removed it and uncommented neofetch, cz it was installed.